### PR TITLE
Let clusters forward to Kubernetes ClusterIP

### DIFF
--- a/internal/config/const.go
+++ b/internal/config/const.go
@@ -37,6 +37,10 @@ const (
 	// DefaultEnableEndpointDiscovery enables EDS for finding the UDP-route backend endpoints
 	DefaultEnableEndpointDiscovery = true
 
+	// EnableRelayToClusterIP allows clients to create transport relay connections to the
+	// ClusterIP of a service. This is useful for hiding the pod IPs behind the ClusterIP.
+	DefaultEnableRelayToClusterIP = true
+
 	// DefaultEnableRenderThrottling makes is possible for the operator to queue up rendering
 	// requests and collapsed them into a single request to decrease operator churn
 	DefaultEnableRenderThrottling = true

--- a/internal/config/vars.go
+++ b/internal/config/vars.go
@@ -14,6 +14,12 @@ var (
 	// EnableEndpointDiscovery enables EDS for finding the UDP-route backend endpoints
 	EnableEndpointDiscovery = DefaultEnableEndpointDiscovery
 
+	// EnableRelayToClusterIP allows clients to create transport relay connections to the
+	// ClusterIP of a Kubernetes serviceThis is useful for hiding the pod IPs behind the
+	// ClusterIP. If both EnableEndpointDiscovery and EnableRelayToClusterIP is on, clients
+	// connect both via the ClusterIP and the direct pod IP.
+	EnableRelayToClusterIP = DefaultEnableRelayToClusterIP
+
 	// EnableRenderThrottling makes is possible for the operator to queue up rendering requests
 	// and collapsed them into a single request to decrease operator churn, default is true
 	EnableRenderThrottling = DefaultEnableRenderThrottling

--- a/internal/renderer/cluster_render.go
+++ b/internal/renderer/cluster_render.go
@@ -53,14 +53,20 @@ func (r *Renderer) renderCluster(ro *gatewayv1alpha2.UDPRoute) (*stunnerconfv1al
 		}
 
 		ep := []string{}
-		if config.EnableEndpointDiscovery == true {
+		if config.EnableEndpointDiscovery == true || config.EnableRelayToClusterIP == true {
 			ctype = stunnerconfv1alpha1.ClusterTypeStatic
 			n := types.NamespacedName{
 				Namespace: ns,
 				Name:      string(b.Name),
 			}
 
-			ep = getEndpointAddrs(n, false)
+			if config.EnableEndpointDiscovery == true {
+				ep = append(ep, getEndpointAddrs(n, false)...)
+			}
+
+			if config.EnableRelayToClusterIP == true {
+				ep = append(ep, getClusterIP(n)...)
+			}
 		} else {
 			// fall back to strict DNS and hope for the best
 			ctype = stunnerconfv1alpha1.ClusterTypeStrictDNS

--- a/internal/renderer/render_pipeline.go
+++ b/internal/renderer/render_pipeline.go
@@ -113,7 +113,7 @@ func (r *Renderer) renderGatewayClass(gc *gatewayv1alpha2.GatewayClass, u *event
 	log.V(1).Info("finding gateway objects")
 	conf.Listeners = []stunnerconfv1alpha1.ListenerConfig{}
 	for _, gw := range r.getGateways4Class(gc) {
-		log.V(2).Info("considering", "gateway", gw.GetName())
+		log.V(2).Info("considering", "gateway", gw.GetName(), "listener-num", len(gw.Spec.Listeners))
 
 		// this also re-inits listener statuses
 		setGatewayStatusScheduled(gw, config.ControllerName)
@@ -144,8 +144,8 @@ func (r *Renderer) renderGatewayClass(gc *gatewayv1alpha2.GatewayClass, u *event
 		} else if ap.addr == "" {
 			log.Info("public service found but no ExternalIP is available for service: " +
 				"this is most probably caused by a fallback to a NodePort access service " +
-				"that does not have a public IP address. NodePorts are not supported, " +
-				"please enableLoadBalancer services")
+				"but no nodes seem to be having a valid external IP address. Hint: " +
+				"enable LoadBalancer services in Kubernetes")
 			ready = false
 		} else {
 			ready = true
@@ -270,7 +270,7 @@ func (r *Renderer) invalidateGatewayClass(gc *gatewayv1alpha2.GatewayClass, u *e
 
 	log.V(1).Info("finding gateway objects")
 	for _, gw := range r.getGateways4Class(gc) {
-		log.V(2).Info("considering", "gateway", gw.GetName())
+		log.V(2).Info("considering", "gateway", gw.GetName(), "listener-num", len(gw.Spec.Listeners))
 
 		// this also re-inits listener statuses
 		setGatewayStatusScheduled(gw, config.ControllerName)

--- a/internal/renderer/service_util.go
+++ b/internal/renderer/service_util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/types"
 	// "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	// "github.com/go-logr/logr"
 	// apiv1 "k8s.io/api/core/v1"
@@ -237,4 +238,18 @@ func createLbService4Gateway(gw *gatewayv1alpha2.Gateway) *corev1.Service {
 	}
 
 	return svc
+}
+
+// find the ClusterIP associated with a service
+func getClusterIP(n types.NamespacedName) []string {
+	ret := []string{}
+
+	s := store.Services.GetObject(n)
+	if s == nil || s.Spec.ClusterIP == "" || s.Spec.ClusterIP == "None" {
+		return ret
+	}
+
+	ret = append(ret, s.Spec.ClusterIP)
+
+	return ret
 }

--- a/test/integration_suite_test.go
+++ b/test/integration_suite_test.go
@@ -217,6 +217,22 @@ var _ = AfterSuite(func() {
 
 // inplace object rewriters
 
+type ServiceMutator func(current *corev1.Service)
+
+func recreateOrUpdateService(f ServiceMutator) {
+	current := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:      testSvc.GetName(),
+		Namespace: testSvc.GetNamespace(),
+	}}
+
+	_, err := ctrlutil.CreateOrUpdate(ctx, k8sClient, current, func() error {
+		testutils.TestSvc.Spec.DeepCopyInto(&current.Spec)
+		f(current)
+		return nil
+	})
+	Expect(err).Should(Succeed())
+}
+
 type UDPRouteMutator func(current *gatewayv1alpha2.UDPRoute)
 
 func recreateOrUpdateUDPRoute(f UDPRouteMutator) {


### PR DESCRIPTION
This feature allows STUNner to forward transport relay connection requests to the ClusterIP associated with  a Kubernetes service, instead directly to the pod IP. This simplifies some of the examples but otherwise does not change basic forwarding behavior. Later, this feature will come in useful when we want to hide media server pod IPs behind the ClusterIP