### PR TITLE
refactor: handle multiple listeners per gateway

### DIFF
--- a/internal/renderer/admin_render_test.go
+++ b/internal/renderer/admin_render_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	// metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	// "k8s.io/apimachinery/pkg/types"
@@ -33,7 +34,7 @@ func TestRenderAdminRender(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class not found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 
@@ -62,7 +63,7 @@ func TestRenderAdminRender(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class not found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 
@@ -91,7 +92,7 @@ func TestRenderAdminRender(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class not found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 

--- a/internal/renderer/auth_render_test.go
+++ b/internal/renderer/auth_render_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	// metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	// "k8s.io/apimachinery/pkg/types"
@@ -32,7 +33,7 @@ func TestRenderAuthRender(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 
@@ -66,7 +67,7 @@ func TestRenderAuthRender(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 
@@ -94,7 +95,7 @@ func TestRenderAuthRender(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 
@@ -118,7 +119,7 @@ func TestRenderAuthRender(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 
@@ -142,7 +143,7 @@ func TestRenderAuthRender(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 
@@ -166,7 +167,7 @@ func TestRenderAuthRender(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 

--- a/internal/renderer/endpoint_util.go
+++ b/internal/renderer/endpoint_util.go
@@ -9,16 +9,16 @@ import (
 )
 
 // find the list of endpoint IP addresses associated with a service
-func getEndpointAddrs(n types.NamespacedName, suppressNotReady bool) []string {
+func getEndpointAddrs(n types.NamespacedName, suppressNotReady bool) ([]string, error) {
 	ret := []string{}
 
 	ep := store.Endpoints.GetObject(n)
 	if ep == nil {
-		return ret
+		return ret, NewNonCriticalRenderError(EndpointNotFound)
 	}
 
-	// allow clients to reach nonready addresses: they have already gone through ICE
-	// negotiation so they may have a better idea on endpoint-readyness than Kubernetes
+	// allow clients to reach not-ready addresses: they have already gone through ICE
+	// negotiation so they may have a better idea on endpoint-readiness than Kubernetes
 	for _, s := range ep.Subsets {
 		for _, a := range s.Addresses {
 			if a.IP != "" {
@@ -34,5 +34,5 @@ func getEndpointAddrs(n types.NamespacedName, suppressNotReady bool) []string {
 		}
 	}
 
-	return ret
+	return ret, nil
 }

--- a/internal/renderer/endpoint_util_test.go
+++ b/internal/renderer/endpoint_util_test.go
@@ -36,8 +36,9 @@ func TestRenderEndpointUtil(t *testing.T) {
 					Namespace: svcs[0].GetNamespace(),
 					Name:      svcs[0].GetName(),
 				}
-				addrs := getEndpointAddrs(n, false)
+				addrs, err := getEndpointAddrs(n, false)
 
+				assert.Nil(t, err, "no error")
 				assert.NotEmpty(t, addrs, "endpoint addrs found")
 				assert.Len(t, addrs, 4, "endpoint addrs len ok")
 				assert.Contains(t, addrs, "1.2.3.4", "addr-1 ok")
@@ -60,8 +61,9 @@ func TestRenderEndpointUtil(t *testing.T) {
 					Namespace: svcs[0].GetNamespace(),
 					Name:      svcs[0].GetName(),
 				}
-				addrs := getEndpointAddrs(n, true)
+				addrs, err := getEndpointAddrs(n, true)
 
+				assert.Nil(t, err, "no error")
 				assert.NotEmpty(t, addrs, "endpoint addrs found")
 				assert.Len(t, addrs, 3, "endpoint addrs len ok")
 				assert.Contains(t, addrs, "1.2.3.4", "addr-1 ok")
@@ -87,8 +89,12 @@ func TestRenderEndpointUtil(t *testing.T) {
 					Namespace: svcs[0].GetNamespace(),
 					Name:      svcs[0].GetName(),
 				}
-				addrs := getEndpointAddrs(n, false)
+				addrs, err := getEndpointAddrs(n, false)
 
+				assert.NotNil(t, err, "error")
+				e, ok := err.(NonCriticalRenderError)
+				assert.True(t, ok, "non-critical error")
+				assert.Equal(t, EndpointNotFound, e.ErrorReason, "endpoint not found error")
 				assert.Empty(t, addrs, "endpoint addrs found")
 			},
 		},
@@ -110,8 +116,12 @@ func TestRenderEndpointUtil(t *testing.T) {
 					Namespace: svcs[0].GetNamespace(),
 					Name:      svcs[0].GetName(),
 				}
-				addrs := getEndpointAddrs(n, false)
+				addrs, err := getEndpointAddrs(n, false)
 
+				assert.NotNil(t, err, "error")
+				e, ok := err.(NonCriticalRenderError)
+				assert.True(t, ok, "non-critical error")
+				assert.Equal(t, EndpointNotFound, e.ErrorReason, "endpoint not found error")
 				assert.Empty(t, addrs, "endpoint addrs found")
 			},
 		},
@@ -133,8 +143,9 @@ func TestRenderEndpointUtil(t *testing.T) {
 					Namespace: svcs[0].GetNamespace(),
 					Name:      svcs[0].GetName(),
 				}
-				addrs := getEndpointAddrs(n, false)
+				addrs, err := getEndpointAddrs(n, false)
 
+				assert.Nil(t, err, "no error")
 				assert.NotEmpty(t, addrs, "endpoint addrs found")
 				assert.Len(t, addrs, 4, "endpoint addrs len ok")
 				assert.Contains(t, addrs, "1.2.3.4", "addr-1 ok")

--- a/internal/renderer/errors.go
+++ b/internal/renderer/errors.go
@@ -1,0 +1,40 @@
+package renderer
+
+// NonCriticalRenderErrorType species the type of a non-critical rendering error
+type NonCriticalRenderErrorType int
+
+const (
+	NoError NonCriticalRenderErrorType = iota
+	InvalidBackendGroup
+	InvalidBackendKind
+	ServiceNotFound
+	ClusterIPNotFound
+	EndpointNotFound
+)
+
+// NonCriticalRenderError is a non-fatal rendering error that affects a Gateway or a Route status
+type NonCriticalRenderError struct {
+	ErrorReason NonCriticalRenderErrorType
+}
+
+// Error returns an error message
+func (e NonCriticalRenderError) Error() string {
+	switch e.ErrorReason {
+	case InvalidBackendGroup:
+		return "Invalid Group in backend reference (expecing: None)"
+	case InvalidBackendKind:
+		return "Invalid Kind in backend reference (expecting Service)"
+	case ServiceNotFound:
+		return "No Service found for backend"
+	case ClusterIPNotFound:
+		return "No ClusterIP found (use a STRICT_DNS cluster if service is headless)"
+	case EndpointNotFound:
+		return "No Endpoint found for backend"
+	}
+	return "No error"
+}
+
+// NewNonCriticalRenderError creates a new non-critical render error object
+func NewNonCriticalRenderError(reason NonCriticalRenderErrorType) NonCriticalRenderError {
+	return NonCriticalRenderError{ErrorReason: reason}
+}

--- a/internal/renderer/gateway_util_test.go
+++ b/internal/renderer/gateway_util_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,7 +40,7 @@ func TestRenderGatewayUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class not found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 
 				gws := r.getGateways4Class(c)
 				assert.Len(t, gws, 0, "gw found")
@@ -61,7 +62,7 @@ func TestRenderGatewayUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class not found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 
 				gws := r.getGateways4Class(c)
 				assert.Len(t, gws, 2, "gw found")
@@ -86,7 +87,7 @@ func TestRenderGatewayUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class not found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 
 				gws := r.getGateways4Class(c)
 				assert.Len(t, gws, 1, "gw found")
@@ -124,7 +125,7 @@ func TestRenderGatewayUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class not found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 
 				gws := r.getGateways4Class(c)
 				assert.Len(t, gws, 1, "gw found")
@@ -161,7 +162,7 @@ func TestRenderGatewayUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 

--- a/internal/renderer/gatewayconfig_util_test.go
+++ b/internal/renderer/gatewayconfig_util_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	// metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	// "k8s.io/apimachinery/pkg/types"
@@ -33,7 +34,7 @@ func TestRenderGatewayConfigUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				assert.Equal(t, "gatewayclass-ok", gc.GetName(), "gateway class name")
 
 				_, err = r.getGatewayConfig4Class(c)
@@ -56,7 +57,7 @@ func TestRenderGatewayConfigUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 
 				_, err = r.getGatewayConfig4Class(c)
 				assert.Error(t, err, "gw-conf found")
@@ -94,7 +95,7 @@ func TestRenderGatewayConfigUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				assert.Equal(t, "gatewayclass-ok", gc.GetName(), "gatewayclass name")
 
 				_, err = r.getGatewayConfig4Class(c)

--- a/internal/renderer/listener_render_test.go
+++ b/internal/renderer/listener_render_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	// metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	// "k8s.io/apimachinery/pkg/types"
@@ -33,7 +34,7 @@ func TestRenderListenerRender(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 
@@ -73,7 +74,7 @@ func TestRenderListenerRender(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 
@@ -103,7 +104,7 @@ func TestRenderListenerRender(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 
@@ -145,7 +146,7 @@ func TestRenderListenerRender(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 
@@ -191,7 +192,7 @@ func TestRenderListenerRender(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 

--- a/internal/renderer/render_pipeline_test.go
+++ b/internal/renderer/render_pipeline_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	// "k8s.io/apimachinery/pkg/types"
@@ -36,7 +37,7 @@ func TestRenderPipeline(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 				assert.Equal(t, "gatewayconfig-ok", c.gwConf.GetName(),
@@ -72,7 +73,7 @@ func TestRenderPipeline(t *testing.T) {
 
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 				assert.Equal(t, "gatewayconfig-ok", c.gwConf.GetName(),
@@ -165,7 +166,7 @@ func TestRenderPipeline(t *testing.T) {
 
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 				assert.Equal(t, "gatewayconfig-ok", c.gwConf.GetName(),
@@ -260,7 +261,7 @@ func TestRenderPipeline(t *testing.T) {
 
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 				assert.Equal(t, "gatewayconfig-ok", c.gwConf.GetName(),
@@ -348,7 +349,7 @@ func TestRenderPipeline(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 				assert.Equal(t, "gatewayconfig-ok", c.gwConf.GetName(),
@@ -467,7 +468,7 @@ func TestRenderPipeline(t *testing.T) {
 				assert.Equal(t, "gatewayclass-ok", gc.GetName(),
 					"gatewayclass name")
 
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.update = event.NewEventUpdate(0)
 				assert.NotNil(t, c.update, "update event create")
 
@@ -541,7 +542,7 @@ func TestRenderPipeline(t *testing.T) {
 				assert.Equal(t, "dummy-gateway-class", gc.GetName(),
 					"gatewayclass name")
 
-				c = &RenderContext{gc: gc}
+				c = &RenderContext{gc: gc, log: logr.Discard()}
 				c.update = event.NewEventUpdate(0)
 				assert.NotNil(t, c.update, "update event create")
 
@@ -663,7 +664,7 @@ func TestRenderPipeline(t *testing.T) {
 				assert.Equal(t, "gatewayclass-ok", gc.GetName(),
 					"gatewayclass name")
 
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.update = event.NewEventUpdate(0)
 				assert.NotNil(t, c.update, "update event create")
 
@@ -740,7 +741,7 @@ func TestRenderPipeline(t *testing.T) {
 				assert.Equal(t, "dummy-gateway-class", gc.GetName(),
 					"gatewayclass name")
 
-				c = &RenderContext{gc: gc}
+				c = &RenderContext{gc: gc, log: logr.Discard()}
 				c.update = event.NewEventUpdate(0)
 				assert.NotNil(t, c.update, "update event create")
 
@@ -862,7 +863,7 @@ func TestRenderPipeline(t *testing.T) {
 				assert.Equal(t, "gatewayclass-ok", gc.GetName(),
 					"gatewayclass name")
 
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.update = event.NewEventUpdate(0)
 				assert.NotNil(t, c.update, "update event create")
 
@@ -940,7 +941,7 @@ func TestRenderPipeline(t *testing.T) {
 				assert.Equal(t, "dummy-gateway-class", gc.GetName(),
 					"gatewayclass name")
 
-				c = &RenderContext{gc: gc}
+				c = &RenderContext{gc: gc, log: logr.Discard()}
 				c.update = event.NewEventUpdate(0)
 				assert.NotNil(t, c.update, "update event create")
 

--- a/internal/renderer/service_util.go
+++ b/internal/renderer/service_util.go
@@ -219,7 +219,7 @@ func createLbService4Gateway(c *RenderContext, gw *gatewayv1alpha2.Gateway) *cor
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: gw.GetNamespace(),
-			Name:      fmt.Sprintf("stunner-gateway-%s-svc", gw.GetName()),
+			Name:      fmt.Sprintf("%s", gw.GetName()),
 			Annotations: map[string]string{
 				config.GatewayAddressAnnotationKey: store.GetObjectKey(gw),
 			},
@@ -227,14 +227,39 @@ func createLbService4Gateway(c *RenderContext, gw *gatewayv1alpha2.Gateway) *cor
 		Spec: corev1.ServiceSpec{
 			Type:     corev1.ServiceTypeLoadBalancer,
 			Selector: map[string]string{config.DefaultStunnerDeploymentLabel: config.DefaultStunnerDeploymentValue},
-			Ports: []corev1.ServicePort{
-				{
-					Name:     fmt.Sprintf("stunner-gateway-%s-udp-port", gw.GetName()),
-					Protocol: corev1.Protocol(gw.Spec.Listeners[0].Protocol),
-					Port:     int32(gw.Spec.Listeners[0].Port),
-				},
-			},
+			Ports:    []corev1.ServicePort{},
 		},
+	}
+
+	// copy all listener ports/protocols from the gateway
+	// proto defaults to the first valid listener protocol
+	serviceProto := ""
+	for _, l := range gw.Spec.Listeners {
+		var proto string
+		switch string(l.Protocol) {
+		case "UDP", "DTLS":
+			proto = "UDP"
+		case "TCP", "TLS":
+			proto = "TCP"
+		default:
+			c.log.V(1).Info("createLbService4Gateway: unknown listener protocol",
+				"gateway", store.GetObjectKey(gw), "listener", l.Name, "protocol", string(l.Protocol))
+			continue
+		}
+		if serviceProto == "" {
+			serviceProto = proto
+		} else if proto != serviceProto {
+			c.log.V(1).Info("createLbService4Gateway: refusing to add listener to service as the listener "+
+				"protocol is different from the service protocol (multi-protocol LB services are not supported)",
+				"gateway", store.GetObjectKey(gw), "listener", l.Name, "listener-protocol", proto,
+				"service-protocol", serviceProto)
+			continue
+		}
+		svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{
+			Name:     fmt.Sprintf("%s-%s", gw.GetName(), strings.ToLower(serviceProto)),
+			Protocol: corev1.Protocol(serviceProto),
+			Port:     int32(l.Port),
+		})
 	}
 
 	// copy the LoadBalancer annotations, if any, from the GatewayConfig to the Service
@@ -245,24 +270,36 @@ func createLbService4Gateway(c *RenderContext, gw *gatewayv1alpha2.Gateway) *cor
 	// forward the first requested address to Kubernetes
 	if len(gw.Spec.Addresses) > 0 {
 		if gw.Spec.Addresses[0].Type == nil ||
-			(gw.Spec.Addresses[0].Type != nil && *gw.Spec.Addresses[0].Type == gatewayv1alpha2.IPAddressType) {
+			(gw.Spec.Addresses[0].Type != nil &&
+				*gw.Spec.Addresses[0].Type == gatewayv1alpha2.IPAddressType) {
 			svc.Spec.LoadBalancerIP = gw.Spec.Addresses[0].Value
 		}
+	}
+
+	// no valid listener in gateway: refuse to create a service
+	if len(svc.Spec.Ports) == 0 {
+		c.log.V(1).Info("createLbService4Gateway: refusing to create a LB service as there "+
+			"is no valid listener found", "gateway", store.GetObjectKey(gw))
+		return nil
 	}
 
 	return svc
 }
 
 // find the ClusterIP associated with a service
-func getClusterIP(n types.NamespacedName) []string {
+func getClusterIP(n types.NamespacedName) ([]string, error) {
 	ret := []string{}
 
 	s := store.Services.GetObject(n)
-	if s == nil || s.Spec.ClusterIP == "" || s.Spec.ClusterIP == "None" {
-		return ret
+	if s == nil {
+		return ret, NewNonCriticalRenderError(ServiceNotFound)
+	}
+
+	if s.Spec.ClusterIP == "" || s.Spec.ClusterIP == "None" {
+		return ret, NewNonCriticalRenderError(ClusterIPNotFound)
 	}
 
 	ret = append(ret, s.Spec.ClusterIP)
 
-	return ret
+	return ret, nil
 }

--- a/internal/renderer/service_util.go
+++ b/internal/renderer/service_util.go
@@ -219,7 +219,7 @@ func createLbService4Gateway(c *RenderContext, gw *gatewayv1alpha2.Gateway) *cor
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: gw.GetNamespace(),
-			Name:      fmt.Sprintf("%s", gw.GetName()),
+			Name:      gw.GetName(),
 			Annotations: map[string]string{
 				config.GatewayAddressAnnotationKey: store.GetObjectKey(gw),
 			},

--- a/internal/renderer/service_util_test.go
+++ b/internal/renderer/service_util_test.go
@@ -6,7 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+
 	// metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	// "sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -34,7 +36,7 @@ func TestRenderServiceUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 
 				gws := r.getGateways4Class(c)
 				assert.Len(t, gws, 1, "gateways for class")
@@ -64,7 +66,7 @@ func TestRenderServiceUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 
 				gws := r.getGateways4Class(c)
 				assert.Len(t, gws, 1, "gateways for class")
@@ -90,7 +92,7 @@ func TestRenderServiceUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 
 				gws := r.getGateways4Class(c)
 				assert.Len(t, gws, 1, "gateways for class")
@@ -115,7 +117,7 @@ func TestRenderServiceUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 
 				gws := r.getGateways4Class(c)
 				assert.Len(t, gws, 1, "gateways for class")
@@ -141,7 +143,7 @@ func TestRenderServiceUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 
 				gws := r.getGateways4Class(c)
 				assert.Len(t, gws, 1, "gateways for class")
@@ -172,7 +174,7 @@ func TestRenderServiceUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 
 				gws := r.getGateways4Class(c)
 				assert.Len(t, gws, 1, "gateways for class")
@@ -224,7 +226,7 @@ func TestRenderServiceUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 
 				gws := r.getGateways4Class(c)
 				assert.Len(t, gws, 1, "gateways for class")
@@ -259,7 +261,7 @@ func TestRenderServiceUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 
 				gws := r.getGateways4Class(c)
 				assert.Len(t, gws, 1, "gateways for class")
@@ -288,7 +290,7 @@ func TestRenderServiceUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 
 				gws := r.getGateways4Class(c)
 				assert.Len(t, gws, 1, "gateways for class")
@@ -311,17 +313,26 @@ func TestRenderServiceUtil(t *testing.T) {
 			},
 		},
 		{
-			name: "lb service",
+			name: "lb service - single listener",
 			cls:  []gatewayv1alpha2.GatewayClass{testutils.TestGwClass},
 			cfs:  []stunnerv1alpha1.GatewayConfig{testutils.TestGwConfig},
 			gws:  []gatewayv1alpha2.Gateway{testutils.TestGw},
 			rs:   []gatewayv1alpha2.UDPRoute{},
 			svcs: []corev1.Service{testutils.TestSvc},
-			prep: func(c *renderTestConfig) {},
+			prep: func(c *renderTestConfig) {
+				w := testutils.TestGw.DeepCopy()
+				w.Spec.Listeners = []gatewayv1alpha2.Listener{{
+					Name:     gatewayv1alpha2.SectionName("gateway-1-listener-udp"),
+					Port:     gatewayv1alpha2.PortNumber(1),
+					Protocol: gatewayv1alpha2.ProtocolType("UDP"),
+				}}
+				c.gws = []gatewayv1alpha2.Gateway{*w}
+
+			},
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 
@@ -349,6 +360,169 @@ func TestRenderServiceUtil(t *testing.T) {
 			},
 		},
 		{
+			name: "lb service - single listener",
+			cls:  []gatewayv1alpha2.GatewayClass{testutils.TestGwClass},
+			cfs:  []stunnerv1alpha1.GatewayConfig{testutils.TestGwConfig},
+			gws:  []gatewayv1alpha2.Gateway{testutils.TestGw},
+			rs:   []gatewayv1alpha2.UDPRoute{},
+			svcs: []corev1.Service{testutils.TestSvc},
+			prep: func(c *renderTestConfig) {
+				w := testutils.TestGw.DeepCopy()
+				w.Spec.Listeners = []gatewayv1alpha2.Listener{{
+					Name:     gatewayv1alpha2.SectionName("gateway-1-listener-udp"),
+					Port:     gatewayv1alpha2.PortNumber(1),
+					Protocol: gatewayv1alpha2.ProtocolType("UDP"),
+				}}
+				c.gws = []gatewayv1alpha2.Gateway{*w}
+			},
+			tester: func(t *testing.T, r *Renderer) {
+				gc, err := r.getGatewayClass()
+				assert.NoError(t, err, "gw-class found")
+				c := &RenderContext{gc: gc, log: logr.Discard()}
+				c.gwConf, err = r.getGatewayConfig4Class(c)
+				assert.NoError(t, err, "gw-conf found")
+
+				gws := r.getGateways4Class(c)
+				assert.Len(t, gws, 1, "gateways for class")
+				gw := gws[0]
+
+				s := createLbService4Gateway(c, gw)
+				assert.NotNil(t, s, "svc create")
+				assert.Equal(t, c.gwConf.GetNamespace(), s.GetNamespace(), "namespace ok")
+
+				as := s.GetAnnotations()
+				assert.Len(t, as, 1, "annotations len")
+				gwa, found := as[config.GatewayAddressAnnotationKey]
+				assert.True(t, found, "annotation found")
+				assert.Equal(t, store.GetObjectKey(gw), gwa, "annotation ok")
+
+				spec := s.Spec
+				assert.Equal(t, corev1.ServiceTypeLoadBalancer, spec.Type, "lb type")
+
+				sp := spec.Ports
+				assert.Len(t, sp, 1, "service-port len")
+				assert.Equal(t, string(gw.Spec.Listeners[0].Protocol), string(sp[0].Protocol), "sp proto")
+				assert.Equal(t, string(gw.Spec.Listeners[0].Port), string(sp[0].Port), "sp port")
+			},
+		},
+		{
+			name: "lb service - single listener, no valid listener",
+			cls:  []gatewayv1alpha2.GatewayClass{testutils.TestGwClass},
+			cfs:  []stunnerv1alpha1.GatewayConfig{testutils.TestGwConfig},
+			gws:  []gatewayv1alpha2.Gateway{testutils.TestGw},
+			rs:   []gatewayv1alpha2.UDPRoute{},
+			svcs: []corev1.Service{testutils.TestSvc},
+			prep: func(c *renderTestConfig) {
+				w := testutils.TestGw.DeepCopy()
+				w.Spec.Listeners = []gatewayv1alpha2.Listener{{
+					Name:     gatewayv1alpha2.SectionName("gateway-1-listener-udp"),
+					Port:     gatewayv1alpha2.PortNumber(1),
+					Protocol: gatewayv1alpha2.ProtocolType("dummy"),
+				}}
+				c.gws = []gatewayv1alpha2.Gateway{*w}
+			},
+			tester: func(t *testing.T, r *Renderer) {
+				gc, err := r.getGatewayClass()
+				assert.NoError(t, err, "gw-class found")
+				c := &RenderContext{gc: gc, log: logr.Discard()}
+				c.gwConf, err = r.getGatewayConfig4Class(c)
+				assert.NoError(t, err, "gw-conf found")
+
+				gws := r.getGateways4Class(c)
+				assert.Len(t, gws, 1, "gateways for class")
+				gw := gws[0]
+
+				s := createLbService4Gateway(c, gw)
+				assert.Nil(t, s, "svc create")
+			},
+		},
+		{
+			name: "lb service - multi-listener, single proto",
+			cls:  []gatewayv1alpha2.GatewayClass{testutils.TestGwClass},
+			cfs:  []stunnerv1alpha1.GatewayConfig{testutils.TestGwConfig},
+			gws:  []gatewayv1alpha2.Gateway{testutils.TestGw},
+			rs:   []gatewayv1alpha2.UDPRoute{},
+			svcs: []corev1.Service{testutils.TestSvc},
+			prep: func(c *renderTestConfig) {
+				w := testutils.TestGw.DeepCopy()
+				w.Spec.Listeners[2].Protocol = gatewayv1alpha2.ProtocolType("UDP")
+				c.gws = []gatewayv1alpha2.Gateway{*w}
+			},
+			tester: func(t *testing.T, r *Renderer) {
+				gc, err := r.getGatewayClass()
+				assert.NoError(t, err, "gw-class found")
+				c := &RenderContext{gc: gc, log: logr.Discard()}
+				c.gwConf, err = r.getGatewayConfig4Class(c)
+				assert.NoError(t, err, "gw-conf found")
+
+				gws := r.getGateways4Class(c)
+				assert.Len(t, gws, 1, "gateways for class")
+				gw := gws[0]
+
+				s := createLbService4Gateway(c, gw)
+				assert.NotNil(t, s, "svc create")
+				assert.Equal(t, c.gwConf.GetNamespace(), s.GetNamespace(), "namespace ok")
+
+				as := s.GetAnnotations()
+				assert.Len(t, as, 1, "annotations len")
+				gwa, found := as[config.GatewayAddressAnnotationKey]
+				assert.True(t, found, "annotation found")
+				assert.Equal(t, store.GetObjectKey(gw), gwa, "annotation ok")
+
+				spec := s.Spec
+				assert.Equal(t, corev1.ServiceTypeLoadBalancer, spec.Type, "lb type")
+
+				sp := spec.Ports
+				assert.Len(t, sp, 2, "service-port len")
+				assert.Equal(t, string(gw.Spec.Listeners[0].Protocol), string(sp[0].Protocol), "sp 1 - proto")
+				assert.Equal(t, string(gw.Spec.Listeners[0].Port), string(sp[0].Port), "sp 1 - port")
+				assert.Equal(t, string(gw.Spec.Listeners[2].Protocol), string(sp[1].Protocol), "sp 2 - proto")
+				assert.Equal(t, string(gw.Spec.Listeners[2].Port), string(sp[1].Port), "sp 2 - port")
+			},
+		},
+		{
+			name: "lb service - multi-listener, multi proto",
+			cls:  []gatewayv1alpha2.GatewayClass{testutils.TestGwClass},
+			cfs:  []stunnerv1alpha1.GatewayConfig{testutils.TestGwConfig},
+			gws:  []gatewayv1alpha2.Gateway{testutils.TestGw},
+			rs:   []gatewayv1alpha2.UDPRoute{},
+			svcs: []corev1.Service{testutils.TestSvc},
+			prep: func(c *renderTestConfig) {
+				w := testutils.TestGw.DeepCopy()
+				w.Spec.Listeners[0].Protocol = gatewayv1alpha2.ProtocolType("dummy-2")
+				c.gws = []gatewayv1alpha2.Gateway{*w}
+			},
+			tester: func(t *testing.T, r *Renderer) {
+				gc, err := r.getGatewayClass()
+				assert.NoError(t, err, "gw-class found")
+				c := &RenderContext{gc: gc, log: logr.Discard()}
+				c.gwConf, err = r.getGatewayConfig4Class(c)
+				assert.NoError(t, err, "gw-conf found")
+
+				gws := r.getGateways4Class(c)
+				assert.Len(t, gws, 1, "gateways for class")
+				gw := gws[0]
+
+				s := createLbService4Gateway(c, gw)
+				assert.NotNil(t, s, "svc create")
+				assert.Equal(t, c.gwConf.GetNamespace(), s.GetNamespace(), "namespace ok")
+
+				as := s.GetAnnotations()
+				assert.Len(t, as, 1, "annotations len")
+				gwa, found := as[config.GatewayAddressAnnotationKey]
+				assert.True(t, found, "annotation found")
+				assert.Equal(t, store.GetObjectKey(gw), gwa, "annotation ok")
+
+				spec := s.Spec
+				assert.Equal(t, corev1.ServiceTypeLoadBalancer, spec.Type, "lb type")
+
+				sp := spec.Ports
+				assert.Len(t, sp, 1, "service-port len")
+				assert.Equal(t, string(gw.Spec.Listeners[2].Protocol), string(sp[0].Protocol), "sp 1 - proto")
+				assert.Equal(t, string(gw.Spec.Listeners[2].Port), string(sp[0].Port), "sp 1 - port")
+			},
+		},
+		{
 			name: "lb service - lb annotations",
 			cls:  []gatewayv1alpha2.GatewayClass{testutils.TestGwClass},
 			cfs:  []stunnerv1alpha1.GatewayConfig{testutils.TestGwConfig},
@@ -365,7 +539,7 @@ func TestRenderServiceUtil(t *testing.T) {
 			tester: func(t *testing.T, r *Renderer) {
 				gc, err := r.getGatewayClass()
 				assert.NoError(t, err, "gw-class found")
-				c := &RenderContext{gc: gc}
+				c := &RenderContext{gc: gc, log: logr.Discard()}
 				c.gwConf, err = r.getGatewayConfig4Class(c)
 				assert.NoError(t, err, "gw-conf found")
 
@@ -397,8 +571,8 @@ func TestRenderServiceUtil(t *testing.T) {
 
 				sp := spec.Ports
 				assert.Len(t, sp, 1, "service-port len")
-				assert.Equal(t, string(gw.Spec.Listeners[0].Protocol), string(sp[0].Protocol), "sp proto")
-				assert.Equal(t, string(gw.Spec.Listeners[0].Port), string(sp[0].Port), "sp port")
+				assert.Equal(t, string(gw.Spec.Listeners[0].Protocol), string(sp[0].Protocol), "sp 1 - proto")
+				assert.Equal(t, string(gw.Spec.Listeners[0].Port), string(sp[0].Port), "sp 1 - port")
 			},
 		},
 	})

--- a/test/integration_test_cases.go
+++ b/test/integration_test_cases.go
@@ -1123,12 +1123,13 @@ var _ = Describe("Integration test:", func() {
 				Equal(string(gatewayv1alpha2.RouteConditionAccepted)))
 			Expect(s.Status).Should(Equal(metav1.ConditionFalse))
 
+			// backendRefs resolved, to ResolvedRefs=True
 			s = meta.FindStatusCondition(ps.Conditions,
 				string(gatewayv1alpha2.RouteConditionResolvedRefs))
 			Expect(s).NotTo(BeNil())
 			Expect(s.Type).Should(
 				Equal(string(gatewayv1alpha2.RouteConditionResolvedRefs)))
-			Expect(s.Status).Should(Equal(metav1.ConditionFalse))
+			Expect(s.Status).Should(Equal(metav1.ConditionTrue))
 		})
 
 		It("changing the auth type", func() {


### PR DESCRIPTION
Breaking changes:
* automatically created load-balancer services are now called the same as the gateway that they belong to
* any existing service with the same name/namespace is automatically rewritten
* the operator tries to create a service-port for each listener of the gateway
* until multi-protocol loadbalancer support goes mainstream, we try to limit multi-listener gateway loadbalancer services to a single ptotocol
* rules are as follows: (1) first valid listener protocol fixes the protocol of the loadbalancer service, (2) all subsequent listeners with the selected protocol are added to the loadbalancer service