### PR TITLE
chore(CI): Propagate helm updates to l7mp/stunner-helm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,11 @@ jobs:
       - name: Get the version
         id: vars
         run: echo ::set-output name=tag::$(echo ${GITHUB_REF:11})
-      - name: Trigger repository dispatch event with passing the tagged version
-        uses: peter-evans/repository-dispatch@v2.1.1
+      - name: Triggering release workflow in the stunner-helm repo
+        uses: convictional/trigger-workflow-and-wait
         with:
-          token: ${{ secrets.WEB_PAT_TOKEN }}
-          repository: l7mp/stunner-helm
-          event-type: release
-          client-payload: '{"tag": "${{steps.vars.outputs.tag}}", "type": "stunner-gateway-operator"}'
-
+          github_token: ${{ secrets.WEB_PAT_TOKEN }}
+          owner: l7mp
+          repo: stunner-helm
+          client_payload: '{"tag": "${{steps.vars.outputs.tag}}", "type": "stunner-gateway-operator"}'
+          workflow_file_name: publish.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
-name: Release
+name: "release"
 
 on:
   push:
     tags:
-      - '*'
+      - 'v[0-9]+.[0-9]+.0'
 
 defaults:
   run:
@@ -47,52 +47,14 @@ jobs:
     name: Push charts to the web
     runs-on: ubuntu-latest
     steps:
-      - name: stunner checkout
-        uses: actions/checkout@v3
-        with:
-          path: stunner-gateway-operator
-          ref: main
-          repository: l7mp/stunner-gateway-operator
       - name: Get the version
         id: vars
         run: echo ::set-output name=tag::$(echo ${GITHUB_REF:11})
-      - name: l7mp.io checkout
-        uses: actions/checkout@v3
+      - name: Trigger repository dispatch event with passing the tagged version
+        uses: peter-evans/repository-dispatch@v2.1.1
         with:
           token: ${{ secrets.WEB_PAT_TOKEN }}
-          path: l7mp.io
-          ref: master
-          repository: l7mp/l7mp.io
-      - name: stunner-helm checkout
-        uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.WEB_PAT_TOKEN }}
-          path: stunner-helm
-          ref: main
           repository: l7mp/stunner-helm
-      - name: Set git config
-        run: |
-          git config --global user.email "l7mp.info@gmail.com"
-          git config --global user.name "BotL7mp"
-      - name: Build helm charts
-        run: |
-          cd stunner-helm/helm
-          sed -ri 's/^(\s*)(version\s*:\s*.*\s*$)/\1version: ${{steps.vars.outputs.tag}}/' stunner-gateway-operator/Chart.yaml
-          sed -ri 's/^(\s*)(appVersion\s*:\s*.*\s*$)/\1appVersion: ${{steps.vars.outputs.tag}}/' stunner-gateway-operator/Chart.yaml
-          sed -ri 's/^(\s*)(          tag\s*:\s*.*\s*$)/\1          tag: ${{steps.vars.outputs.tag}}/' stunner-gateway-operator/values.yaml
-          helm package *
-      - name: Update l7mp.io
-        run: |
-          cp stunner-helm/helm/*.tgz l7mp.io/stunner
-          helm repo index l7mp.io/stunner/ --url https://l7mp.io/stunner
-          cd l7mp.io
-          git add .
-          git commit -m "Update helm charts from l7mp/stunner-gateway-operator" -m "(triggered by the 'Helm release' github action.)"
-          git push origin master
-      - name: Update stunner
-        run: |
-          cd stunner-helm
-          rm helm/*.tgz
-          git add .
-          git commit -m "Update helm chart from l7mp/stunner-gateway-operator" -m "(triggered by the 'Helm release' github action.)"
-          git push origin main
+          event-type: release
+          client-payload: '{"tag": "${{steps.vars.outputs.tag}}", "type": "stunner-gateway-operator"}'
+


### PR DESCRIPTION
WIP DO NOT MERGE YET

Building the chart was moved to the l7mp/stunner-helm repository. In the new version, we use [this](https://github.com/marketplace/actions/repository-dispatch) action. It sends an event to the given repository. A PAT is used to authenticate the request.

- [ ] Need to find a way to test 