### PR TITLE
feature: Use Gateway Addresses as rendered Service's external IPs

### DIFF
--- a/internal/renderer/service_util.go
+++ b/internal/renderer/service_util.go
@@ -372,6 +372,10 @@ func createLbService4Gateway(c *RenderContext, gw *gwapiv1a2.Gateway) *corev1.Se
 		if gw.Spec.Addresses[0].Type == nil ||
 			(gw.Spec.Addresses[0].Type != nil &&
 				*gw.Spec.Addresses[0].Type == gwapiv1a2.IPAddressType) {
+			// only the first address can be used because
+			// stunner is limited to use a single public address
+			// https://github.com/l7mp/stunner-gateway-operator/issues/32#issuecomment-1648035135
+			svc.Spec.ExternalIPs = []string{gw.Spec.Addresses[0].Value}
 			svc.Spec.LoadBalancerIP = gw.Spec.Addresses[0].Value
 		}
 	}

--- a/internal/renderer/service_util_test.go
+++ b/internal/renderer/service_util_test.go
@@ -1457,7 +1457,7 @@ func TestRenderServiceUtil(t *testing.T) {
 			},
 		},
 		{
-			name: "public address hint in GateWay Spec",
+			name: "public address hint in Gateway Spec",
 			cls:  []gwapiv1a2.GatewayClass{testutils.TestGwClass},
 			cfs:  []stnrv1a1.GatewayConfig{testutils.TestGwConfig},
 			gws:  []gwapiv1a2.Gateway{testutils.TestGw},
@@ -1467,6 +1467,10 @@ func TestRenderServiceUtil(t *testing.T) {
 				gw := testutils.TestGw.DeepCopy()
 				at := gwapiv1a2.IPAddressType
 				gw.Spec.Addresses = []gwapiv1a2.GatewayAddress{
+					{
+						Type:  &at,
+						Value: "1.1.1.1",
+					},
 					{
 						Type:  &at,
 						Value: "1.2.3.4",
@@ -1489,7 +1493,9 @@ func TestRenderServiceUtil(t *testing.T) {
 				assert.NotNil(t, s, "svc create")
 				assert.Equal(t, c.gwConf.GetNamespace(), s.GetNamespace(), "namespace ok")
 				assert.Equal(t, corev1.ServiceTypeLoadBalancer, s.Spec.Type, "lb type")
-				assert.Equal(t, s.Spec.LoadBalancerIP, "1.2.3.4", "svc address")
+				assert.Equal(t, s.Spec.LoadBalancerIP, "1.1.1.1", "svc loadbalancerip")
+				assert.Equal(t, len(s.Spec.ExternalIPs), 1, "svc externalips list length")
+				assert.Equal(t, s.Spec.ExternalIPs[0], "1.1.1.1", "svc externalips")
 			},
 		},
 	})

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -49,7 +49,7 @@ const (
 	// // the gateway controller.
 	// GatewayManagedLabelValue = "gateway"
 
-	// DefaultStunnerConfigMapName names a ConfigMap by the operator to render the stunnerd
+	// DefaultConfigMapName names a ConfigMap by the operator to render the stunnerd
 	// config file.
 	DefaultConfigMapName = "stunnerd-config"
 
@@ -65,7 +65,7 @@ const (
 	// DefaultEnableEndpointDiscovery enables EDS for finding the UDP-route backend endpoints.
 	DefaultEnableEndpointDiscovery = true
 
-	// EnableRelayToClusterIP allows clients to create transport relay connections to the
+	// DefaultEnableRelayToClusterIP allows clients to create transport relay connections to the
 	// ClusterIP of a service.
 	DefaultEnableRelayToClusterIP = true
 


### PR DESCRIPTION
#32 
No annotation. If `gw.spec.addresses` is specified and is correct then forward it to the rendered service's `spec.externalIPs` as well.