### PR TITLE
Handle existing load balancer class

### DIFF
--- a/internal/renderer/service_util.go
+++ b/internal/renderer/service_util.go
@@ -188,26 +188,30 @@ func (r *Renderer) createLbService4Gateway(c *RenderContext, gw *gwapiv1b1.Gatew
 		// should never happen
 		return nil
 	}
-
-	svc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: gw.GetNamespace(),
-			Name:      gw.GetName(),
-			Labels: map[string]string{
-				opdefault.OwnedByLabelKey:         opdefault.OwnedByLabelValue,
-				opdefault.RelatedGatewayNamespace: gw.GetNamespace(),
-				opdefault.RelatedGatewayKey:       gw.GetName(),
-			},
-			Annotations: map[string]string{
-				opdefault.RelatedGatewayKey: store.GetObjectKey(gw),
-			},
-		},
-		Spec: corev1.ServiceSpec{
-			Type:     opdefault.DefaultServiceType,
-			Selector: map[string]string{},
-			Ports:    []corev1.ServicePort{},
-		},
+	// Fetch the service as it exists in the store, this should prevent changing fields we shouldn't
+	svc := store.Services.GetObject(types.NamespacedName{Namespace: gw.GetNamespace(), Name: gw.GetName()})
+	if svc == nil {
+	  svc = &corev1.Service{
+	  	ObjectMeta: metav1.ObjectMeta{
+	  		Namespace: gw.GetNamespace(),
+	  		Name:      gw.GetName(),
+	  		Labels: map[string]string{
+	  			opdefault.OwnedByLabelKey:         opdefault.OwnedByLabelValue,
+	  			opdefault.RelatedGatewayNamespace: gw.GetNamespace(),
+	  			opdefault.RelatedGatewayKey:       gw.GetName(),
+	  		},
+	  		Annotations: map[string]string{
+	  			opdefault.RelatedGatewayKey: store.GetObjectKey(gw),
+	  		},
+	  	},
+	  	Spec: corev1.ServiceSpec{
+	  		Type:     opdefault.DefaultServiceType,
+	  		Selector: map[string]string{},
+	  		Ports:    []corev1.ServicePort{},
+	  	},
+	  }
 	}
+
 
 	// set labels
 	switch config.DataplaneMode {


### PR DESCRIPTION
We frequently see an error like the following:

```
"error": "cannot upsert service \"stunner/gateway\": Service \"gateway\" is invalid: spec.loadBalancerClass: Invalid value: \"null\": may not change once set"
```

We're using the AWS load balancer controller, which sets that field when the service is created and handles the creation of a load balancer for us.

I traced this down to how the service gets recreated each time. We have a cache of the current state of the service in the global store, so we can use this to get the current values. We need to then be careful about adding ports, but other than that the change is pretty straightforward.