### PR TITLE
Fix error in upsertDeployment (currentspec.Tolerations wrong length)

### DIFF
--- a/internal/updater/client_util.go
+++ b/internal/updater/client_util.go
@@ -249,7 +249,7 @@ func (u *Updater) upsertDeployment(dp *appv1.Deployment, gen int) (ctrlutil.Oper
 		}
 
 		if dpspec.Tolerations != nil {
-			currentspec.Tolerations = make([]corev1.Toleration, len(dpspec.Containers))
+			currentspec.Tolerations = make([]corev1.Toleration, len(dpspec.Tolerations))
 			for i := range dpspec.Tolerations {
 				dpspec.Tolerations[i].DeepCopyInto(&currentspec.Tolerations[i])
 			}


### PR DESCRIPTION
Hello!

While updating my test Stunner to `0.19.0`, I observed the container `stunner-gateway-operator` crashing.
After switching to the `dev` tag, I found this error stack trace in the log:

```
panic: runtime error: index out of range [1] with length 1

goroutine 42 [running]:
github.com/l7mp/stunner-gateway-operator/internal/updater.(*Updater).upsertDeployment.func1()
	github.com/l7mp/stunner-gateway-operator/internal/updater/client_util.go:254 +0xb5e
sigs.k8s.io/controller-runtime/pkg/controller/controllerutil.mutate(0x188c9e0?, {{0xc00022e800?, 0x1adde42?}, {0xc00022e7f0?, 0x1d954a0?}}, {0x1dabf40, 0xc000e46508})
	sigs.k8s.io/controller-runtime@v0.17.0/pkg/controller/controllerutil/controllerutil.go:426 +0x49
sigs.k8s.io/controller-runtime/pkg/controller/controllerutil.CreateOrPatch({0x1d954a0, 0xc00047cbe0}, {0x1d9fee0, 0xc00014d680}, {0x1dabf40, 0xc000e46508}, 0xc000e57b38)
	sigs.k8s.io/controller-runtime@v0.17.0/pkg/controller/controllerutil/controllerutil.go:361 +0x4f5
github.com/l7mp/stunner-gateway-operator/internal/updater.(*Updater).upsertDeployment(0xc00047cb90, 0xc000becf08, 0x1)
	github.com/l7mp/stunner-gateway-operator/internal/updater/client_util.go:207 +0x2c5
github.com/l7mp/stunner-gateway-operator/internal/updater.(*Updater).ProcessUpdate(0xc00047cb90, 0xc0004975e0)
	github.com/l7mp/stunner-gateway-operator/internal/updater/updater.go:136 +0xb86
github.com/l7mp/stunner-gateway-operator/internal/updater.(*Updater).Start.func1()
	github.com/l7mp/stunner-gateway-operator/internal/updater/updater.go:57 +0x18a
created by github.com/l7mp/stunner-gateway-operator/internal/updater.(*Updater).Start in goroutine 1
	github.com/l7mp/stunner-gateway-operator/internal/updater/updater.go:42 +0x9d
```

Following the lead, I found that `currentspec.Tolerations` was likely created with the wrong length value.
This change fixes the crashing in my setup :)