### PR TITLE
feat: Set LB service session affinity to "clientIP"

### DIFF
--- a/internal/renderer/service_util.go
+++ b/internal/renderer/service_util.go
@@ -310,9 +310,10 @@ func (r *Renderer) createLbService4Gateway(c *RenderContext, gw *gwapiv1.Gateway
 				Annotations: requestedAnnotations,
 			},
 			Spec: corev1.ServiceSpec{
-				Type:     opdefault.DefaultServiceType,
-				Selector: map[string]string{},
-				Ports:    []corev1.ServicePort{},
+				Type:            opdefault.DefaultServiceType,
+				Selector:        map[string]string{},
+				Ports:           []corev1.ServicePort{},
+				SessionAffinity: corev1.ServiceAffinityClientIP,
 			},
 		}
 	} else {

--- a/internal/renderer/service_util_test.go
+++ b/internal/renderer/service_util_test.go
@@ -519,6 +519,8 @@ func TestRenderServiceUtil(t *testing.T) {
 				assert.Equal(t, corev1.ServiceTypeLoadBalancer, spec.Type, "lb type")
 				assert.Equal(t, defaultExternalTrafficPolicy, spec.ExternalTrafficPolicy,
 					"ext traffic policy default")
+				assert.Equal(t, corev1.ServiceAffinityClientIP, spec.SessionAffinity,
+					"session affinity")
 
 				sp := spec.Ports
 				assert.Len(t, sp, 1, "service-port len")


### PR DESCRIPTION
Enabling sticky sessions for the LB service may improve the robustness of TURN connection routing during scale-out/in. Unfortunately it is not perfectly understood at this point how this feature works for UDP sessions across different LB controllers so we must do some testing before enabling this by setting by default. 