### PR TITLE
Use ClientIP SessionAffinity in gateway service

### DIFF
--- a/internal/renderer/service_util.go
+++ b/internal/renderer/service_util.go
@@ -380,6 +380,9 @@ func (r *Renderer) createLbService4Gateway(c *RenderContext, gw *gwapiv1.Gateway
 		svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyType("")
 	}
 
+	// session affinity: to ensure that the same client always hits the same pod
+	svc.Spec.SessionAffinity = corev1.ServiceAffinityClientIP
+
 	// nodeport
 	listenerNodeports := make(map[string]int)
 	if v, ok := annotations[opdefault.NodePortAnnotationKey]; ok {


### PR DESCRIPTION
When scaling stunnerd to multiple instances, it appears that requests for the same client gets distributed across all replicas, which results in the following error when the replica processing the request does not know about the client:

```
18:04:29.915306 server.go:229: turn ERROR: Failed to handle datagram: unable to handle ChannelData from x.x.x.x:36651: no allocation found x.x.x.x:36651::3478
```
where `x.x.x.x` is redacted IP.

This PR sets `SessionAffinity` in the service to `ClientIP` so that the same client always hits the same replica.