### PR TITLE
chore(CI/CD): Add pr-image-builder workflow

### DIFF
--- a/.github/workflows/pr-image-builder.yaml
+++ b/.github/workflows/pr-image-builder.yaml
@@ -9,9 +9,9 @@ jobs:
   #   name: Run unit tests
   #   uses: l7mp/stunner-gateway-operator/.github/workflows/test.yml@main
 
-  push_to_registry:
+  build_image_and_push_to_registry:
+    if: github.event.action != 'closed' && github.repository == 'l7mp/stunner-gateway-operator'
     name: Push Docker image to DockerHub
-    if: github.repository == 'l7mp/stunner-gateway-operator'
     runs-on: ubuntu-latest
 
     steps:
@@ -53,3 +53,18 @@ jobs:
               repo: context.repo.repo,
               body: comment,
             });
+
+  delete_docker_image_tag:
+    if: github.event.action == 'closed' && github.repository == 'l7mp/stunner-gateway-operator'
+    name: Delete Docker Image Tag from DockerHub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete Docker Image Tag
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          curl -s -u "$DOCKER_USER:$DOCKER_TOKEN" \
+            -X DELETE "https://hub.docker.com/v2/repositories/l7mp/stunner-gateway-operator/tags/pr-$PR_NUMBER/" \
+            -w "HTTP Response Code: %{http_code}\n"

--- a/.github/workflows/pr-image-builder.yaml
+++ b/.github/workflows/pr-image-builder.yaml
@@ -2,7 +2,7 @@ name: Build and Push Docker Image for PR
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, closed]
 
 jobs:
   # run_unit_tests:

--- a/.github/workflows/pr-image-builder.yaml
+++ b/.github/workflows/pr-image-builder.yaml
@@ -59,12 +59,21 @@ jobs:
     name: Delete Docker Image Tag from DockerHub
     runs-on: ubuntu-latest
     steps:
-      - name: Delete Docker Image Tag
+      - name: Get Docker Hub Token
+        id: get_token
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
         run: |
+          TOKEN=$(curl -s -X POST "https://hub.docker.com/v2/users/login/" \
+            -H "Content-Type: application/json" \
+            -d '{"username": "'$DOCKER_USER'", "password": "'$DOCKER_TOKEN'"}' | jq -r .token)
+          echo "token=$TOKEN" >> $GITHUB_ENV
+      - name: Delete Docker Image Tag
+        env:
+          TOKEN: ${{ env.token }}
+        run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
-          curl -s -u "$DOCKER_USER:$DOCKER_TOKEN" \
+          curl -s -H "Authorization: Bearer $TOKEN" \
             -X DELETE "https://hub.docker.com/v2/repositories/l7mp/stunner-gateway-operator/tags/pr-$PR_NUMBER/" \
             -w "HTTP Response Code: %{http_code}\n"

--- a/.github/workflows/pr-image-builder.yaml
+++ b/.github/workflows/pr-image-builder.yaml
@@ -1,0 +1,54 @@
+name: Build and Push Docker Image
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  # run_unit_tests:
+  #   name: Run unit tests
+  #   uses: l7mp/stunner-gateway-operator/.github/workflows/test.yml@main
+
+  push_to_registry:
+    name: Push Docker image to DockerHub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and Push Docker Image
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            l7mp/stunner-gateway-operator:pr-${{ github.event.pull_request.number }}
+
+      - name: Comment on PR
+        if: success() && github.event_name == 'pull_request'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const comment = `The Docker image for this pull request (#${prNumber}) has been successfully built and pushed to DockerHub as \`l7mp/stunner-gateway-operator:pr-${prNumber}\`.`;
+            github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment,
+            });

--- a/.github/workflows/pr-image-builder.yaml
+++ b/.github/workflows/pr-image-builder.yaml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Image
+name: Build and Push Docker Image for PR
 
 on:
   pull_request:
@@ -11,6 +11,7 @@ jobs:
 
   push_to_registry:
     name: Push Docker image to DockerHub
+    if: github.repository == 'l7mp/stunner-gateway-operator'
     runs-on: ubuntu-latest
 
     steps:
@@ -45,7 +46,7 @@ jobs:
         with:
           script: |
             const prNumber = context.issue.number;
-            const comment = `The Docker image for this pull request (#${prNumber}) has been successfully built and pushed to DockerHub as \`l7mp/stunner-gateway-operator:pr-${prNumber}\`.`;
+            const comment = `The Docker image for this pull request (#${prNumber}) has been successfully built and pushed to DockerHub as \`docker.io/l7mp/stunner-gateway-operator:pr-${prNumber}\`.`;
             github.rest.issues.createComment({
               issue_number: prNumber,
               owner: context.repo.owner,


### PR DESCRIPTION
This PR adds a workflow that builds a Docker image based on the pull requests. It gets triggered on additional commits also. 
The image naming is `l7mp/stunner-gateway-operator:pr-<pr-number>`.

The workflow comments on the PR with the built image name to notify the user.

Currently, the run unit test job is disabled, might be useful to enable it later.