### PR TITLE
Feat/active loops metrics

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,11 +1,26 @@
 package metrics
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
+
+// LoopHeartbeatInterval is how often each worker goroutine bumps its heartbeat
+// gauge during idle periods. Picked low enough to give plenty of margin under
+// LoopStalenessThreshold while remaining negligible overhead.
+const LoopHeartbeatInterval = 5 * time.Second
+
+// LoopStalenessThreshold is the maximum acceptable age of a worker goroutine's
+// last heartbeat before the /healthz check considers the loop hung. The
+// heartbeat is bumped on every select wakeup, including at the start of the
+// work branch — so during a single long-running iteration (e.g. a slow
+// ProcessUpdate) the gauge does not refresh until that iteration completes.
+// Existing duration histograms cap at 60s, so this threshold is set well above
+// that to avoid restarting pods that are slow rather than wedged.
+const LoopStalenessThreshold = 2 * time.Minute
 
 // reconcileTimeBuckets matches the bucket boundaries used by controller-runtime for
 // controller_runtime_reconcile_time_seconds, so that all operator histograms are
@@ -83,7 +98,80 @@ var (
 		Name: "stunner_gateway_operator_generation_last_acked",
 		Help: "Generation number of the last update acknowledged by the updater thread.",
 	})
+
+	// OperatorLoopLastActive is the unix timestamp of the most recent operator
+	// main-loop select iteration. A stale value proves the loop is wedged.
+	OperatorLoopLastActive = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "stunner_gateway_operator_operator_loop_last_active_timestamp_seconds",
+		Help: "Unix timestamp of the last operator main-loop select iteration; stale values indicate the loop is hung.",
+	})
+
+	// RendererLoopLastActive is the unix timestamp of the most recent renderer
+	// goroutine select iteration.
+	RendererLoopLastActive = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "stunner_gateway_operator_renderer_loop_last_active_timestamp_seconds",
+		Help: "Unix timestamp of the last renderer goroutine select iteration; stale values indicate the loop is hung.",
+	})
+
+	// UpdaterLoopLastActive is the unix timestamp of the most recent updater
+	// goroutine select iteration.
+	UpdaterLoopLastActive = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "stunner_gateway_operator_updater_loop_last_active_timestamp_seconds",
+		Help: "Unix timestamp of the last updater goroutine select iteration; stale values indicate the loop is hung.",
+	})
 )
+
+// In-process mirrors of the heartbeat gauges. Stored as atomic unix-seconds so
+// the /healthz check can read them without going through the prometheus client's
+// dto.Metric write path. Zero means "never recorded yet" — treat as healthy
+// until first heartbeat fires.
+var (
+	operatorLoopLastActive atomic.Int64
+	rendererLoopLastActive atomic.Int64
+	updaterLoopLastActive  atomic.Int64
+)
+
+// RecordOperatorHeartbeat marks the operator main loop as alive at the current
+// time. Call this from every branch of the operator select loop.
+func RecordOperatorHeartbeat() {
+	now := time.Now().Unix()
+	operatorLoopLastActive.Store(now)
+	OperatorLoopLastActive.Set(float64(now))
+}
+
+// RecordRendererHeartbeat marks the renderer goroutine as alive at the current time.
+func RecordRendererHeartbeat() {
+	now := time.Now().Unix()
+	rendererLoopLastActive.Store(now)
+	RendererLoopLastActive.Set(float64(now))
+}
+
+// RecordUpdaterHeartbeat marks the updater goroutine as alive at the current time.
+func RecordUpdaterHeartbeat() {
+	now := time.Now().Unix()
+	updaterLoopLastActive.Store(now)
+	UpdaterLoopLastActive.Set(float64(now))
+}
+
+// OperatorLoopAge returns the time since the operator main loop last ran a
+// select iteration. Returns 0 if no heartbeat has been recorded yet.
+func OperatorLoopAge() time.Duration { return loopAge(&operatorLoopLastActive) }
+
+// RendererLoopAge returns the time since the renderer goroutine last ran a
+// select iteration. Returns 0 if no heartbeat has been recorded yet.
+func RendererLoopAge() time.Duration { return loopAge(&rendererLoopLastActive) }
+
+// UpdaterLoopAge returns the time since the updater goroutine last ran a
+// select iteration. Returns 0 if no heartbeat has been recorded yet.
+func UpdaterLoopAge() time.Duration { return loopAge(&updaterLoopLastActive) }
+
+func loopAge(a *atomic.Int64) time.Duration {
+	ts := a.Load()
+	if ts == 0 {
+		return 0
+	}
+	return time.Since(time.Unix(ts, 0))
+}
 
 func init() {
 	ctrlmetrics.Registry.MustRegister(
@@ -96,5 +184,8 @@ func init() {
 		ReconcileEventsTotal,
 		Generation,
 		GenerationLastAcked,
+		OperatorLoopLastActive,
+		RendererLoopLastActive,
+		UpdaterLoopLastActive,
 	)
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,60 @@
+package metrics
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoopAgeZeroBeforeFirstHeartbeat(t *testing.T) {
+	var a atomic.Int64
+	assert.Equal(t, time.Duration(0), loopAge(&a), "loopAge with no heartbeat")
+}
+
+func TestLoopAgeAfterHeartbeat(t *testing.T) {
+	var a atomic.Int64
+	a.Store(time.Now().Add(-30 * time.Second).Unix())
+
+	got := loopAge(&a)
+	assert.GreaterOrEqual(t, got, 25*time.Second, "loopAge lower bound")
+	assert.LessOrEqual(t, got, 35*time.Second, "loopAge upper bound")
+}
+
+func TestRecordHeartbeats(t *testing.T) {
+	cases := []struct {
+		name   string
+		record func()
+		age    func() time.Duration
+		mirror *atomic.Int64
+	}{
+		{"operator", RecordOperatorHeartbeat, OperatorLoopAge, &operatorLoopLastActive},
+		{"renderer", RecordRendererHeartbeat, RendererLoopAge, &rendererLoopLastActive},
+		{"updater", RecordUpdaterHeartbeat, UpdaterLoopAge, &updaterLoopLastActive},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.mirror.Store(0)
+			assert.Equal(t, time.Duration(0), tc.age(), "age before first heartbeat")
+
+			before := time.Now().Unix()
+			tc.record()
+			after := time.Now().Unix()
+
+			stored := tc.mirror.Load()
+			assert.GreaterOrEqual(t, stored, before, "mirror lower bound")
+			assert.LessOrEqual(t, stored, after, "mirror upper bound")
+			assert.LessOrEqual(t, tc.age(), 2*time.Second, "age right after heartbeat")
+		})
+	}
+}
+
+func TestStalenessThresholdAboveHistogramCap(t *testing.T) {
+	// The reconcile-time histograms top out at 60s; the staleness threshold
+	// must sit comfortably above that so slow-but-alive iterations aren't
+	// flagged as hung.
+	assert.Greater(t, LoopStalenessThreshold, 60*time.Second, "staleness > histogram cap")
+	assert.Less(t, LoopHeartbeatInterval, LoopStalenessThreshold, "heartbeat < staleness")
+}

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -142,10 +142,20 @@ func (o *Operator) eventLoop(ctx context.Context, cancel context.CancelFunc) {
 	throttler.Stop()
 	throttling := false
 
+	// Independent heartbeat ticker — the throttler above is Stop()ed during
+	// idle periods, so it cannot double as a liveness signal.
+	heartbeat := time.NewTicker(metrics.LoopHeartbeatInterval)
+	defer heartbeat.Stop()
+	metrics.RecordOperatorHeartbeat()
+
 	for {
 		select {
 
+		case <-heartbeat.C:
+			metrics.RecordOperatorHeartbeat()
+
 		case e := <-o.operatorCh.Channel():
+			metrics.RecordOperatorHeartbeat()
 			switch e.GetType() {
 			case event.EventTypeUpdate:
 				if n := sendCoalesced(o.updaterCh, e); n > 0 {
@@ -187,6 +197,7 @@ func (o *Operator) eventLoop(ctx context.Context, cancel context.CancelFunc) {
 			}
 
 		case <-throttler.C:
+			metrics.RecordOperatorHeartbeat()
 			throttling = false
 			throttler.Stop()
 

--- a/internal/renderer/renderer.go
+++ b/internal/renderer/renderer.go
@@ -87,9 +87,17 @@ func (r *renderer) Start(ctx context.Context) error {
 			}
 		}()
 
+		heartbeat := time.NewTicker(metrics.LoopHeartbeatInterval)
+		defer heartbeat.Stop()
+		metrics.RecordRendererHeartbeat()
+
 		for {
 			select {
+			case <-heartbeat.C:
+				metrics.RecordRendererHeartbeat()
+
 			case e := <-r.renderCh:
+				metrics.RecordRendererHeartbeat()
 				switch e.GetType() {
 				case event.EventTypeRender:
 					// prepare a new update event Render will populate config

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -78,9 +78,17 @@ func (u *Updater) Start(ctx context.Context) error {
 		defer close(u.updaterCh)
 		defer u.opCh.Put()
 
+		heartbeat := time.NewTicker(metrics.LoopHeartbeatInterval)
+		defer heartbeat.Stop()
+		metrics.RecordUpdaterHeartbeat()
+
 		for {
 			select {
+			case <-heartbeat.C:
+				metrics.RecordUpdaterHeartbeat()
+
 			case e := <-u.updaterCh:
+				metrics.RecordUpdaterHeartbeat()
 				if e.GetType() != event.EventTypeUpdate {
 					u.log.Info("Updater thread received unknown event",
 						"event", e.String())


### PR DESCRIPTION
## Summary

Adds per-thread heartbeat metrics for the operator, renderer, and updater goroutines so a wedged select loop can be detected externally (Prometheus) and in-process (e.g. by a `/healthz` check).

- New gauges `stunner_gateway_operator_{operator,renderer,updater}_loop_last_active_timestamp_seconds` exposing the unix timestamp of the most recent select iteration on each loop.
- Each loop gets a dedicated `time.Ticker` at `LoopHeartbeatInterval` (5s) plus a heartbeat call on every real event branch — the existing operator throttler is `Stop()`ed when idle, so it can't double as a liveness signal.
- Atomic in-process mirrors (`OperatorLoopAge` / `RendererLoopAge` / `UpdaterLoopAge`) let a liveness probe read freshness without going through the Prometheus dto write path.
- `LoopStalenessThreshold` set to 2m, comfortably above the 60s cap on the existing reconcile-time histograms so slow-but-alive iterations aren't flagged as hung.
- Unit tests in `internal/metrics/metrics_test.go` covering the age helper, the three `Record*Heartbeat` round-trips, and the constant invariants (using `testify/assert` to match the rest of the repo).

## Notes for reviewers

- The heartbeat is bumped *at the start* of the event branch, so a single long-running `ProcessUpdate` won't refresh the gauge until it returns — this is intentional (a wedged handler should look stale) but worth confirming against the 2m threshold.
- Zero-valued age means "never recorded yet"; callers should treat that as healthy until the first tick.
- No end-to-end "wedge the renderer, watch the gauge stall" test yet — would live in the renderer/updater/operator packages rather than `metrics`. Happy to add if reviewers want it.

## Test plan

- [x] `go test ./internal/metrics/` passes.
- [ ] Run the operator locally, scrape `/metrics`, confirm all three new gauges advance ~every 5s under idle load.
- [ ] Simulate a wedge (e.g. block the renderer channel) and confirm the corresponding gauge stops advancing while the others continue.