### PR TITLE
Avoid recursive lock

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -120,11 +120,12 @@ func (s *storeImpl) Objects() []client.Object {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
-	ret := make([]client.Object, s.Len())
-	i := 0
+	// Note: do not call s.Len() here — it would re-acquire the read lock and
+	// deadlock against a pending Reset() writer (RWMutex blocks new RLocks
+	// once a writer is queued). We already hold RLock, so read len directly.
+	ret := make([]client.Object, 0, len(s.objects))
 	for _, o := range s.objects {
-		ret[i] = o
-		i += 1
+		ret = append(ret, o)
 	}
 
 	return ret

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -4,7 +4,9 @@ import (
 	// "fmt"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"sync"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -244,4 +246,52 @@ func TestFilterLabels(t *testing.T) {
 		assert.True(t, ok, "input map preserved")
 		assert.Len(t, in, 2)
 	})
+}
+
+// TestStoreObjectsResetNoDeadlock guards against a regression where Objects()
+// re-acquired the read lock while already holding it (it sized its result slice
+// via Len(), which RLocks again). A concurrent Reset() writer queuing for the
+// write lock would then block that re-entrant RLock forever, since Go's RWMutex
+// starves new readers once a writer is waiting — deadlocking the renderer
+// (Objects) against the reconciler (Reset). Readers and writers hammer the same
+// store concurrently; without the fix this never completes and the watchdog
+// fires.
+func TestStoreObjectsResetNoDeadlock(t *testing.T) {
+	s := NewStore()
+	s.Reset([]client.Object{&o1, &o2, &o3})
+
+	const workers = 50
+	const iters = 200
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		var wg sync.WaitGroup
+		for i := 0; i < workers; i++ {
+			wg.Add(2)
+			// readers: the renderer path, Objects()
+			go func() {
+				defer wg.Done()
+				for j := 0; j < iters; j++ {
+					s.Objects()
+				}
+			}()
+			// writers: the reconciler path, Reset()
+			go func() {
+				defer wg.Done()
+				for j := 0; j < iters; j++ {
+					s.Reset([]client.Object{&o1, &o2, &o3})
+				}
+			}()
+		}
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+		// completed without deadlocking: confirm Objects() still returns sanely
+		assert.Len(t, s.Objects(), 3, "objects after concurrent access")
+	case <-time.After(10 * time.Second):
+		t.Fatal("deadlock: concurrent Objects()/Reset() did not complete — Objects() likely re-acquires the read lock it already holds")
+	}
 }


### PR DESCRIPTION
## Fix RWMutex deadlock in `store.Objects()`

### Symptom
<img width="736" height="298" alt="Screenshot 2026-06-04 at 2 44 18 AM" src="https://github.com/user-attachments/assets/d3257e3a-c4a0-4e46-9783-440e100f4447" />

The gateway operator's reconciler stops making progress and hangs indefinitely. A live pprof goroutine dump showed two goroutines stuck on the same `storeImpl` instance, with the CPU profile idle — a hard deadlock, not a spin:

```
goroutine 421 [sync.RWMutex.Lock, 11 minutes]:   # reconciler
  gatewayReconciler.Reconcile → store.(*storeImpl).Reset   store/store.go:68   (wants write Lock)

goroutine 44 [sync.RWMutex.RLock, 11 minutes]:   # renderer
  renderer.Render → ... → GatewayClassStore.GetAll
    → store.(*storeImpl).Objects → store.(*storeImpl).Len   store/store.go:114  (wants RLock, already holds one)
```

### Root cause
`Objects()` holds `RLock`, then calls `Len()` which takes `RLock` **again** to size its result slice:

```go
func (s *storeImpl) Objects() []client.Object {
    s.lock.RLock()
    defer s.lock.RUnlock()
    ret := make([]client.Object, s.Len())   // ← re-acquires RLock
    ...
}
```

Recursive read-locking is normally fine, but Go's `sync.RWMutex` blocks any *new* `RLock` once a writer is queued (to prevent writer starvation). So when `Reset()` requests the write `Lock()` in between, the inner `Len()` `RLock` blocks behind it — and `Reset()` can't proceed because the outer `RLock` is still held. Three-party circular wait → permanent deadlock between the renderer and the reconciler.

### Fix
Don't re-lock. `Objects()` already holds the read lock, so read `len(s.objects)` directly:

```go
func (s *storeImpl) Objects() []client.Object {
    s.lock.RLock()
    defer s.lock.RUnlock()
    ret := make([]client.Object, 0, len(s.objects))
    for _, o := range s.objects {
        ret = append(ret, o)
    }
    return ret
}
```

Audited the other lockers (`Get`, `Upsert`, `Remove`, `Flush`) — none re-lock while holding the lock, so `Objects()` was the only offender.

### Test
Added `TestStoreObjectsResetNoDeadlock`: concurrent `Objects()` (renderer) vs `Reset()` (reconciler) hammering the same store, guarded by a watchdog.

| State | Result |
|---|---|
| With fix | **PASS in 0.03s**, `-race` clean |
| Buggy `Objects()` restored | **FAIL** — watchdog fires at exactly 10.00s (the deadlock) |
| Full `./internal/store` suite, `-race` | `ok` |

The test is proven to go red on the original bug, so it will catch any reintroduced recursive `RLock` on this store.
