### PR TITLE
Use net.JoinHostPort to handle ipv6 addresses

### DIFF
--- a/internal/renderer/dataplane_util.go
+++ b/internal/renderer/dataplane_util.go
@@ -146,7 +146,7 @@ func generateDataplanePodSpec(c *RenderContext, dataplane *stnrgwv1.Dataplane) (
 		Host:   config.ConfigDiscoveryAddress,
 	}
 	if cdsAddr.Port() == "" {
-		cdsAddr.Host = fmt.Sprintf("%s:%s", config.ConfigDiscoveryAddress, port)
+		cdsAddr.Host = net.JoinHostPort(config.ConfigDiscoveryAddress, port)
 	}
 
 	podSpec := corev1.PodSpec{

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 	"time"
@@ -152,16 +153,20 @@ func main() {
 	}
 	setupLog.Info("customer key", "status", keyStatus)
 
-	// CDS address not overrridden on the command line: use env var
+	// CDS address not overridden on the command line: use env var
 	config.ConfigDiscoveryAddress = cdsAddr
 	if podAddr, ok := os.LookupEnv(envVarAddress); ok {
 		// default port
-		as := strings.Split(cdsAddr, ":")
-		if len(as) != 2 || as[1] == "" {
+		_, port, err := net.SplitHostPort(cdsAddr)
+		if err != nil {
+			setupLog.Error(err, "invalid CDS server address", "address", cdsAddr)
+			os.Exit(1)
+		}
+		if port == "" {
 			setupLog.Info("invalid CDS server address", "address", cdsAddr)
 			os.Exit(1)
 		}
-		config.ConfigDiscoveryAddress = fmt.Sprintf("%s:%s", podAddr, as[1])
+		config.ConfigDiscoveryAddress = net.JoinHostPort(podAddr, port)
 	}
 
 	setupLog.Info("config discovery server", "local-addr", cdsAddr,


### PR DESCRIPTION
This makes a few improvements for ipv6 and dualstack environments. 
- There's a few places where host+port are joined naively, which doesn't work for IPv6. Replaced these with using `net.JoinHostPort` which handles IPv6 addresses properly.
- ~Adds an annotation that can be set on a gateway to control the IPFamilyPolicy of the service that gets created (at least on my cluster, even though the cluster is dual stack, the family policy seems to default to single stack and I want a way to control that)~ pulled this out for now to make the change a little cleaner