### PR TITLE
Add annotation to use status.podIPs instead of status.podIP in STUNNER_ADDR

### DIFF
--- a/internal/renderer/dataplane_util.go
+++ b/internal/renderer/dataplane_util.go
@@ -131,7 +131,9 @@ func (r *dataplaneGenerator) generate(c *RenderContext) (client.Object, error) {
 func generateDataplanePodSpec(c *RenderContext, dataplane *stnrgwv1.Dataplane) (corev1.PodSpec, error) {
 	gw := c.gws.GetFirst()
 	podAddrFieldSelector := corev1.ObjectFieldSelector{FieldPath: "status.podIP"}
+	podAddrsFieldSelector := corev1.ObjectFieldSelector{FieldPath: "status.podIPs"}
 	podAddrEnvVarSource := corev1.EnvVarSource{FieldRef: &podAddrFieldSelector}
+	podAddrsEnvVarSource := corev1.EnvVarSource{FieldRef: &podAddrsFieldSelector}
 	nodeNameFieldSelector := corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"}
 	nodeNameEnvVarSource := corev1.EnvVarSource{FieldRef: &nodeNameFieldSelector}
 	livenessProbe, readinessProbe := getHealthCheckParameters(c)
@@ -149,6 +151,11 @@ func generateDataplanePodSpec(c *RenderContext, dataplane *stnrgwv1.Dataplane) (
 		cdsAddr.Host = fmt.Sprintf("%s:%s", config.ConfigDiscoveryAddress, port)
 	}
 
+	stunnerAddr := podAddrEnvVarSource
+	if value, ok := gw.GetAnnotations()[opdefault.ListenAllPodIPsAnnotationKey]; ok && value == opdefault.ListenAllPodIPsAnnotationValue {
+		stunnerAddr = podAddrsEnvVarSource
+	}
+
 	podSpec := corev1.PodSpec{
 		Containers: []corev1.Container{{
 			Name:    opdefault.DefaultStunnerdInstanceName,
@@ -160,7 +167,7 @@ func generateDataplanePodSpec(c *RenderContext, dataplane *stnrgwv1.Dataplane) (
 			// Args:    []string{"-w", "-c", "/etc/stunnerd/stunnerd.conf", "--udp-thread-num=16"},
 			Env: []corev1.EnvVar{{
 				Name:      "STUNNER_ADDR", // default transport relay address
-				ValueFrom: &podAddrEnvVarSource,
+				ValueFrom: &stunnerAddr,
 			}, {
 				Name:  stnrconfv1.DefaultEnvVarName, // gateway name for creating the stunnerd id
 				Value: gw.GetName(),

--- a/internal/renderer/dataplane_util_test.go
+++ b/internal/renderer/dataplane_util_test.go
@@ -5,6 +5,7 @@ import (
 	//"fmt"
 	"fmt"
 	"net/url"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -136,6 +137,16 @@ func TestRenderDataplaneUtil(t *testing.T) {
 				assert.Equal(t, testutils.TestResourceLimit, container.Resources.Limits, "container 1 - resource limits")
 				assert.Equal(t, testutils.TestResourceRequest, container.Resources.Requests, "container 1 - resource req")
 				assert.Equal(t, corev1.PullAlways, container.ImagePullPolicy, "container 1 - pull policy")
+
+				// Without the annotation, STUNNER_ADDR should be from status.podIP
+				stunnerAddrIndex := slices.IndexFunc(container.Env, func(e corev1.EnvVar) bool {
+					return e.Name == "STUNNER_ADDR"
+				})
+				assert.GreaterOrEqual(t, stunnerAddrIndex, 0, "container 1 - has STUNNER_ADDR env var")
+				stunnerAddr := container.Env[stunnerAddrIndex]
+				assert.NotNil(t, stunnerAddr.ValueFrom, "container 1 - Env.STUNNER_ADDR.ValueFrom")
+				assert.NotNil(t, stunnerAddr.ValueFrom.FieldRef, "container 1 - Env.STUNNER_ADDR.ValueFrom.FieldRef")
+				assert.Equal(t, "status.podIP", stunnerAddr.ValueFrom.FieldRef.FieldPath, "container 1 - Env.STUNNER_ADDR.ValueFrom.FieldRef.FieldPath")
 
 				action := corev1.HTTPGetAction{
 					Path:   "/live",
@@ -472,6 +483,56 @@ func TestRenderDataplaneUtil(t *testing.T) {
 				assert.True(t, ok, "annotations: related gw")
 				// annotation is gw-namespace/gw-name
 				assert.Equal(t, store.GetObjectKey(gw), gwName, "related-gateway annotation")
+			},
+		},
+		{
+			name: "listen on all pod ips",
+			cls:  []gwapiv1.GatewayClass{testutils.TestGwClass},
+			cfs:  []stnrgwv1.GatewayConfig{testutils.TestGwConfig},
+			gws:  []gwapiv1.Gateway{testutils.TestGw},
+			dps:  []stnrgwv1.Dataplane{testutils.TestDataplane},
+			prep: func(c *renderTestConfig) {
+				gw := testutils.TestGw.DeepCopy()
+				gw.SetAnnotations(map[string]string{
+					"stunner.l7mp.io/listen-all-pod-ips": "true",
+				})
+				c.gws = []gwapiv1.Gateway{*gw}
+			},
+			tester: func(t *testing.T, r *renderer) {
+				gc, err := r.getGatewayClass()
+				assert.NoError(t, err, "gw-class found")
+				c := &RenderContext{gc: gc, gws: store.NewGatewayStore(), log: log}
+				c.gwConf, err = r.getGatewayConfig4Class(c)
+				assert.NoError(t, err, "gw-conf found")
+				assert.Equal(t, "gatewayconfig-ok", c.gwConf.GetName(),
+					"gatewayconfig name")
+
+				c.update = event.NewEventUpdate(0)
+				assert.NotNil(t, c.update, "update event create")
+
+				gws := r.getGateways4Class(c)
+				assert.Len(t, gws, 1, "gateways for class")
+				gw := gws[0]
+				c.gws.ResetGateways([]*gwapiv1.Gateway{gw})
+
+				obj, err := r.generateDataplane(c)
+				assert.NoError(t, err, "create deployment")
+
+				deploy, ok := obj.(*appv1.Deployment)
+				assert.True(t, ok, "deployment cast")
+
+				podSpec := &deploy.Spec.Template.Spec
+				assert.True(t, len(podSpec.Containers) >= 1, "containers len")
+				container := podSpec.Containers[0]
+				stunnerAddrIndex := slices.IndexFunc(container.Env, func(e corev1.EnvVar) bool {
+					return e.Name == "STUNNER_ADDR"
+				})
+				// With the annotation, STUNNER_ADDR should be from status.podIPs
+				assert.GreaterOrEqual(t, stunnerAddrIndex, 0, "container 1 - has STUNNER_ADDR env var")
+				stunnerAddr := container.Env[stunnerAddrIndex]
+				assert.NotNil(t, stunnerAddr.ValueFrom, "container 1 - Env.STUNNER_ADDR.ValueFrom")
+				assert.NotNil(t, stunnerAddr.ValueFrom.FieldRef, "container 1 - Env.STUNNER_ADDR.ValueFrom.FieldRef")
+				assert.Equal(t, "status.podIPs", stunnerAddr.ValueFrom.FieldRef.FieldPath, "container 1 - Env.STUNNER_ADDR.ValueFrom.FieldRef.FieldPath")
 			},
 		},
 	})

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -115,6 +115,15 @@ const (
 	// MixedProtocolAnnotationValue is the expected value in order to enable mixed protocol LBs.
 	MixedProtocolAnnotationValue = "true"
 
+	// ListenAllPodIPsAnnotationKey is the name(key) of the Gateway annotation that is used to
+	// tell the operator to set STUNNER_ADDR using status.podIPs, instead of status.podIP. This
+	// allows the stunnerd pods to listen on all pod ips, not just the first one.
+	ListenAllPodIPsAnnotationKey = "stunner.l7mp.io/listen-all-pod-ips"
+
+	// ListenAllPodIPsAnnotationValue is the expected value in order to enable listening on all
+	// pod ips.
+	ListenAllPodIPsAnnotationValue = "true"
+
 	// ExternalTrafficPolicyAnnotationKey is the name(key) of the Gateway annotation that is
 	// used to control whether ExternalTrafficPolicy=Local is enabled on a LB Service that
 	// exposes a Gateway, see https://github.com/l7mp/stunner-gateway-operator/issues/47.


### PR DESCRIPTION
This adds an annotation that can be applied to a gateway to tell the operator to use the `status.podIPs` fieldRef instead of `status.podIP` in STUNNER_ADDR to allow stunnerd to listen on all pod ip addresses instead of just the first. It depends on https://github.com/l7mp/stunner/pull/230 which implements the handling of the comma separated list of addresses that `status.podIPs` results in. As described in that PR, this is useful for dualstack environments.